### PR TITLE
CVSB-17727 - Trailer certificates not being received in prod

### DIFF
--- a/src/functions/govNotify.ts
+++ b/src/functions/govNotify.ts
@@ -33,8 +33,10 @@ const govNotify: Handler = async (event: SQSEvent, context?: Context, callback?:
 
     objectPutEvent.Records.forEach((s3Record: S3EventRecord) => {
       const s3Object: any = s3Record.s3.object;
+      // Object key may have spaces or unicode non-ASCII characters.
+      const decodedS3Key = decodeURIComponent(s3Object.key.replace(/\+/g, " "));
 
-      const notifyPromise = downloadService.getCertificate(s3Object.key)
+      const notifyPromise = downloadService.getCertificate(decodedS3Key)
         .then((notifyPartialParams: any) => {
           if (!notifyPartialParams.shouldEmailCertificate || notifyPartialParams.shouldEmailCertificate === "true") {
             return notifyService.sendNotification(notifyPartialParams);

--- a/src/services/S3BucketService.ts
+++ b/src/services/S3BucketService.ts
@@ -1,10 +1,8 @@
-import S3, { Metadata } from "aws-sdk/clients/s3";
-import { AWSError, config as AWSConfig } from "aws-sdk";
-import { Readable } from "stream";
-import { Configuration } from "../utils/Configuration";
-import { IS3Config } from "../models";
-import { ManagedUpload } from "aws-sdk/lib/s3/managed_upload";
-import { PromiseResult } from "aws-sdk/lib/request";
+import S3 from "aws-sdk/clients/s3";
+import {AWSError, config as AWSConfig} from "aws-sdk";
+import {Configuration} from "../utils/Configuration";
+import {IS3Config} from "../models";
+import {PromiseResult} from "aws-sdk/lib/request";
 /* tslint:disable */
 const AWSXRay = require("aws-xray-sdk");
 
@@ -21,22 +19,6 @@ class S3BucketService {
     this.s3Client = AWSXRay.captureAWSClient(s3Client);
 
     AWSConfig.s3 = config;
-  }
-
-  /**
-   * Uploads a file to an S3 bucket
-   * @param bucketName - the bucket to upload to
-   * @param fileName - the name of the file
-   * @param content - contents of the file
-   * @param metadata - optional metadata
-   */
-  public upload(bucketName: string, fileName: string, content: Buffer | Uint8Array | Blob | string | Readable, metadata?: Metadata): Promise<ManagedUpload.SendData> {
-    return this.s3Client.upload({
-      Bucket: bucketName,
-      Key: `${process.env.BRANCH}/${fileName}`,
-      Body: content,
-      Metadata: metadata
-    }).promise();
   }
 
   /**


### PR DESCRIPTION
Trailer certificates not being received in prod bug - S3 replaces spaces in the key with "+" and encodes special characters, causing the lambda to not find the certificate in S3 for VINs that have spaces/special characters.
This ticket covers the decoding of the S3 key.

https://jira.dvsacloud.uk/browse/CVSB-17727