### PR TITLE
VTA-83: Switch to use dev version of gov notify

### DIFF
--- a/src/assets/enum.ts
+++ b/src/assets/enum.ts
@@ -1,12 +1,9 @@
-export enum TEMPLATEIDS {
-  CertificateEmail = "1b602e0e-b53a-452a-858f-c5831ef3ed70",
-}
-
 export enum ERRORS {
   NotifyConfigNotDefined = "The Notify config is not defined in the config file.",
   DynamoDBConfigNotDefined = "DynamoDB config is not defined in the config file.",
   LambdaInvokeConfigNotDefined = "Lambda Invoke config is not defined in the config file.",
   EventIsEmpty = "Event is empty",
   SECRET_ENV_VAR_NOT_EXIST = "SECRET_NAME environment variable does not exist.",
+  TEMPLATE_ID_ENV_VAR_NOT_EXIST = "TEMPLATE_ID environment variable does not exist.",
   SECRET_FILE_NOT_EXIST = "The secret file does not exist.",
 }

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -25,3 +25,4 @@ s3:
   remote: {}
 notify:
   api_key:
+  templateId: ff36dae2-937e-4883-9e25-e776fa6af665

--- a/src/functions/govNotify.ts
+++ b/src/functions/govNotify.ts
@@ -33,6 +33,7 @@ const govNotify: Handler = async (event: SQSEvent, context?: Context, callback?:
     console.log(`SQS RECORD: ${JSON.stringify(sqsRecord)}`);
     const objectPutEvent: S3Event = JSON.parse(sqsRecord.body);
 
+    if (objectPutEvent.Records) {
     objectPutEvent.Records.forEach((s3Record: S3EventRecord) => {
       const s3Object: any = s3Record.s3.object;
       // Object key may have spaces or unicode non-ASCII characters.
@@ -46,6 +47,7 @@ const govNotify: Handler = async (event: SQSEvent, context?: Context, callback?:
 
       notifyPromises.push(notifyPromise);
     });
+    }
   });
 
   return Promise.all(notifyPromises).catch((error: any) => {

--- a/src/functions/govNotify.ts
+++ b/src/functions/govNotify.ts
@@ -28,9 +28,7 @@ const govNotify: Handler = async (event: SQSEvent, context?: Context, callback?:
   const notifyService: NotificationService = new NotificationService(notifyClient);
   const notifyPromises: Array<Promise<any>> = [];
 
-  console.log(`EVENT.RECORDS: ${JSON.stringify(event.Records)}`);
   event.Records.forEach((sqsRecord: SQSRecord) => {
-    console.log(`SQS RECORD: ${JSON.stringify(sqsRecord)}`);
     const objectPutEvent: S3Event = JSON.parse(sqsRecord.body);
 
     if (objectPutEvent.Records) {

--- a/src/functions/govNotify.ts
+++ b/src/functions/govNotify.ts
@@ -28,7 +28,9 @@ const govNotify: Handler = async (event: SQSEvent, context?: Context, callback?:
   const notifyService: NotificationService = new NotificationService(notifyClient);
   const notifyPromises: Array<Promise<any>> = [];
 
+  console.log(`EVENT.RECORDS: ${JSON.stringify(event.Records)}`);
   event.Records.forEach((sqsRecord: SQSRecord) => {
+    console.log(`SQS RECORD: ${JSON.stringify(sqsRecord)}`);
     const objectPutEvent: S3Event = JSON.parse(sqsRecord.body);
 
     objectPutEvent.Records.forEach((s3Record: S3EventRecord) => {

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -5,6 +5,7 @@ interface IInvokeConfig {
 
 interface INotifyConfig {
   api_key: string;
+  templateId: string;
 }
 
 interface IS3Config {

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,32 +1,35 @@
 // @ts-ignore
 import { NotifyClient } from "notifications-node-client";
-import { TEMPLATEIDS } from "../assets/enum";
+import {Configuration} from "../utils/Configuration";
 
 /**
  * Service class for Certificate Notifications
  */
 class NotificationService {
   private readonly notifyClient: NotifyClient;
+  private readonly config: Configuration;
 
   constructor(notifyClient: NotifyClient) {
     this.notifyClient = notifyClient;
+    this.config = Configuration.getInstance();
   }
 
   /**
    * Sending email with the certificate according to the given params
    * @param params - personalization details,email and certificate
    */
-  public sendNotification(notifyPartialParams: any) {
+  public async sendNotification(notifyPartialParams: any) {
     const emailDetails = {
       personalisation: {
         ...notifyPartialParams.personalisation,
         link_to_document: this.notifyClient.prepareUpload(notifyPartialParams.certificate),
       },
     };
+    const templateId = await this.config.getTemplateIdFromEV();
 
-    console.log(`Sent email using ${TEMPLATEIDS.CertificateEmail} templateId, ${notifyPartialParams.personalisation.test_type_name} test type name and ${notifyPartialParams.personalisation.date_of_issue} date of issue`);
+    console.log(`Sent email using ${templateId} templateId, ${notifyPartialParams.personalisation.test_type_name} test type name and ${notifyPartialParams.personalisation.date_of_issue} date of issue`);
     return this.notifyClient
-      .sendEmail(TEMPLATEIDS.CertificateEmail, notifyPartialParams.email, emailDetails)
+      .sendEmail(templateId, notifyPartialParams.email, emailDetails)
       .then((response: any) => {
         return response;
       })

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { NotifyClient } from "notifications-node-client";
-import {Configuration} from "../utils/Configuration";
+import { Configuration } from "../utils/Configuration";
 
 /**
  * Service class for Certificate Notifications

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -95,6 +95,25 @@ class Configuration {
     return this.config.notify;
   }
 
+
+  /**
+   * Retrieves the templateId from environment variable
+   */
+  public async getTemplateIdFromEV(): Promise<string> {
+    if (!process.env.BRANCH || process.env.BRANCH === "local")  {
+      if (!this.config.notify.templateId) {
+        throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
+      } else {
+        return this.config.notify.templateId
+      }
+    } else {
+      if (!process.env.TEMPLATE_ID) {
+      throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
+      }
+      return process.env.TEMPLATE_ID;
+    }
+  }
+
   /**
    * Sets the secrets needed to use GovNotify
    * @returns Promise<void>

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -95,20 +95,19 @@ class Configuration {
     return this.config.notify;
   }
 
-
   /**
    * Retrieves the templateId from environment variable
    */
   public async getTemplateIdFromEV(): Promise<string> {
-    if (!process.env.BRANCH || process.env.BRANCH === "local")  {
+    if (!process.env.BRANCH || process.env.BRANCH === "local") {
       if (!this.config.notify.templateId) {
         throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
       } else {
-        return this.config.notify.templateId
+        return this.config.notify.templateId;
       }
     } else {
       if (!process.env.TEMPLATE_ID) {
-      throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
+        throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
       }
       return process.env.TEMPLATE_ID;
     }

--- a/tests/resources/badConfig.yml
+++ b/tests/resources/badConfig.yml
@@ -1,0 +1,3 @@
+notify:
+  api_key:
+  templateId:


### PR DESCRIPTION
## Switch cert-gov-notify service to use dev version of gov notify

This ticket is to switch the cvs-tsk- cert-gov-notify service to use the dev version of gov notify in all environments other than Prod.
[link to main ticket number](https://jira.dvsacloud.uk/browse/VTA-83)
[link to subtask ticket number](https://jira.dvsacloud.uk/browse/VTA-110)

## Checklist

- [x] Branch is rebased against the latest develop
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
