### PR TITLE
feat(cb2-8313): fix enquiry bucket name on feature branches

### DIFF
--- a/src/services/CertificateDownloadService.ts
+++ b/src/services/CertificateDownloadService.ts
@@ -20,14 +20,14 @@ class CertificateDownloadService {
    * @param fileName - the file name of the certificate you want to download
    */
   public getCertificate(fileName: string) {
-    const bucket = fileName.includes("VOSA") ? "cvs-enquiry-document-feed" : "cvs-cert";
+    const bucket = fileName.includes("VOSA") ? `cvs-enquiry-document-feed-${process.env.BRANCH}` : `cvs-cert-${process.env.BUCKET}`;
 
     return this.s3Client
-      .download(`${bucket}-${process.env.BUCKET}`, fileName)
+      .download(bucket, fileName)
       .then((result: S3.Types.GetObjectOutput) => {
         console.log(`Downloading result: ${JSON.stringify(this.cleanForLogging(result))}`);
 
-        return bucket === "cvs-enquiry-document-feed" ? this.generateTFLFeedParams(result) : result.Metadata!["cert-type"] ? this.generateCertificatePartialParams(result) : this.generatePartialParams(result);
+        return fileName.includes("VOSA") ? this.generateTFLFeedParams(result) : result.Metadata!["cert-type"] ? this.generateCertificatePartialParams(result) : this.generatePartialParams(result);
       })
       .catch((error) => {
         console.error(error);


### PR DESCRIPTION
## Update enquiry service to use TFL view

In feature environments, the certificates are stored in the develop bucket, however feature environments get their own bucket for enquiry service documents. This leads to some errors in feature environments. 

With this change, uploaded TFL documents to the enquiry bucket in feature environments actually reach gov-notify.

![image](https://github.com/dvsa/cvs-tsk-cert-gov-notify/assets/104442665/e0c86f9c-44c3-4166-94a9-4703bbe96911)
![image](https://github.com/dvsa/cvs-tsk-cert-gov-notify/assets/104442665/e59e86d1-ed8e-4d8f-98d4-e24d132f05bb)


[CB2-8313](https://dvsa.atlassian.net/browse/CB2-8313)

## Checklist

- [ ] Branch is rebased against the latest develop
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
