### PR TITLE
VTA-1676: bump node notifications version following notify change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9384,9 +9384,9 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
       "requires": {
         "jws": "^3.2.2",
         "lodash": "^4.17.21",
@@ -9395,9 +9395,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -10456,9 +10456,9 @@
       "dev": true
     },
     "notifications-node-client": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-6.0.0.tgz",
-      "integrity": "sha512-QP4BSODBJROy2YU6sLHSx0uXKeINNyFcdMSHjczeffTMLlQ51SHrP+0n+UHMA0ta+gWuGGsjHfG3tpPtsZ1uNg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-7.0.1.tgz",
+      "integrity": "sha512-Nx9hOiyrQp4yMo9cWmsjhFoHCgKLWFyhwIfB3bzS+2jsAWitOi4KOaFNQHXwdrYzjtdIWalLv6YTrrEPUhn7OQ==",
       "requires": {
         "axios": "^0.25.0",
         "jsonwebtoken": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "aws-xray-sdk": "^3.3.4",
     "js-yaml": "^3.13.1",
     "node-yaml": "^4.0.1",
-    "notifications-node-client": "^6.0.0",
+    "notifications-node-client": "^7.0.1",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {


### PR DESCRIPTION
## Use latest version of node notifications

Further to the breaking changes introduced by GOV Notify on 11th July that disregards that email verification has been set to false, after contacting Notify support that advised they would rectify the issue in v7.0.1 and asked us to bump to that version as soon as possible.
[https://dvsa.atlassian.net/browse/VTA-1676](VTA-1676)

## Checklist

- [X] Branch is rebased against the latest develop
- [X] PR title includes the JIRA ticket number
- [X] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
