### PR TITLE
feat(cb2-16613): handle axios error and bump dep as per npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6406,9 +6406,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/src/functions/govNotify.ts
+++ b/src/functions/govNotify.ts
@@ -1,6 +1,7 @@
 import { S3Client } from '@aws-sdk/client-s3';
 import { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from 'aws-lambda';
 import 'reflect-metadata';
+import { AxiosError } from 'axios';
 import Container from 'typedi';
 import { ERRORS } from '../assets/enum';
 import { NotificationService } from '../services/NotificationService';
@@ -30,6 +31,11 @@ const govNotify: Handler = async (event: SQSEvent): Promise<SQSBatchResponse> =>
 				await processRequest.process(record);
 			}
 		} catch (error) {
+			const isAxiosError = typeof error === 'object' && error && 'isAxiosError' in error && error.isAxiosError;
+			if (isAxiosError) {
+				console.error('ERROR: Axios response error', (error as AxiosError).response?.data);
+			}
+			console.error(error);
 			console.error(error);
 			batchItemFailures.push({ itemIdentifier: sqsRecord.messageId });
 		}


### PR DESCRIPTION
## Improve Axios Error Handling in cert-gov-notify

Added some additional error handling in the function catch block to allows us to easily identify any axios specific issues n the future. 

Bumped version of axios, as per npm audit.

[CB2-16613](https://dvsa.atlassian.net/browse/CB2-16613)

## Checklist

- [X] Branch is rebased against the latest develop
- [X] PR title includes the JIRA ticket number
- [X] Squashed commits contain the JIRA ticket number
- [X] Link to the PR added to the repo


[CB2-16613]: https://dvsa.atlassian.net/browse/CB2-16613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ